### PR TITLE
Equicord'u privcord'a taşı

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Equilotl
 
-The Equicord Installer allows you to install [Equicord, the cutest Discord Desktop client mod](https://github.com/Equicord/Equicord)
+The Privcord Installer allows you to install [Privcord](https://github.com/kanvekin/Privcord)
 
 ![image](https://i.imgur.com/oHN41ss.png)
 
 ## Usage
 
 Windows
-- [GUI](https://github.com/Equicord/Equilotl/releases/latest/download/Equilotl.exe) 
-- [CLI](https://github.com/Equicord/Equilotl/releases/latest/download/EquilotlCli.exe)
+- [GUI](https://github.com/kanvekin/Privcord/releases/latest/download/Equilotl.exe) 
+- [CLI](https://github.com/kanvekin/Privcord/releases/latest/download/EquilotlCli.exe)
 
 MacOS
-- [GUI](https://github.com/Equicord/Equilotl/releases/latest/download/Equilotl.MacOS.zip)
+- [GUI](https://github.com/kanvekin/Privcord/releases/latest/download/Equilotl.MacOS.zip)
 
 Linux 
-- [GUI](https://github.com/Equicord/Equilotl/releases/latest/download/Equilotl-x11)
-- [CLI](https://github.com/Equicord/Equilotl/releases/latest/download/EquilotlCli-Linux)
+- [GUI](https://github.com/kanvekin/Privcord/releases/latest/download/Equilotl-x11)
+- [CLI](https://github.com/kanvekin/Privcord/releases/latest/download/EquilotlCli-Linux)
 ## Building from source
 
 ### Prerequisites 
@@ -71,4 +71,4 @@ go build --tags cli
 ```
 
 You might want to pass some flags to this command to get a better build.
-See [the GitHub workflow](https://github.com/Equicord/Equilotl/blob/main/.github/workflows/release.yml) for what flags I pass or if you want more precise instructions
+See [the GitHub workflow](https://github.com/kanvekin/Privcord/blob/main/.github/workflows/release.yml) for what flags I pass or if you want more precise instructions

--- a/app_asar.go
+++ b/app_asar.go
@@ -21,14 +21,14 @@ type asarEntry struct {
 
 // Ported from https://github.com/GeopJr/asar-cr/blob/cd7695b7c913bf921d9fb6600eaeb1400e3ba225/src/asar-cr/pack.cr#L61
 
-func WriteAppAsar(outFile string, equicordAsarPath string) error {
+func WriteAppAsar(outFile string, privcordAsarPath string) error {
 	header := make(map[string]map[string]asarEntry)
 	files := make(map[string]asarEntry)
 	header["files"] = files
 
 	fileContents := ""
 
-	patcherPathB, _ := json.Marshal(equicordAsarPath)
+    patcherPathB, _ := json.Marshal(privcordAsarPath)
 	indexJsContents := "require(" + string(patcherPathB) + ")"
 	indexJsBytes := len([]byte(indexJsContents))
 	fileContents += indexJsContents

--- a/cli.go
+++ b/cli.go
@@ -48,9 +48,9 @@ func main() {
 	var helpFlag = flag.Bool("help", false, "View usage instructions")
 	var versionFlag = flag.Bool("version", false, "View the program version")
 	var updateSelfFlag = flag.Bool("update-self", false, "Update me to the latest version")
-	var installFlag = flag.Bool("install", false, "Install Equicord")
-	var updateFlag = flag.Bool("repair", false, "Repair Equicord")
-	var uninstallFlag = flag.Bool("uninstall", false, "Uninstall Equicord")
+    var installFlag = flag.Bool("install", false, "Install Privcord")
+    var updateFlag = flag.Bool("repair", false, "Repair Privcord")
+    var uninstallFlag = flag.Bool("uninstall", false, "Uninstall Privcord")
 	var installOpenAsarFlag = flag.Bool("install-openasar", false, "Install OpenAsar")
 	var uninstallOpenAsarFlag = flag.Bool("uninstall-openasar", false, "Uninstall OpenAsar")
 	var locationFlag = flag.String("location", "", "The location of the Discord install to modify")
@@ -107,10 +107,10 @@ func main() {
 			}
 		}()
 
-		choices := []string{
-			"Install Equicord",
-			"Repair Equicord",
-			"Uninstall Equicord",
+        choices := []string{
+            "Install Privcord",
+            "Repair Privcord",
+            "Uninstall Privcord",
 			"Install OpenAsar",
 			"Uninstall OpenAsar",
 			"View Help Menu",
@@ -146,8 +146,8 @@ func main() {
 		errSilent = PromptDiscord("patch", *locationFlag, *branchFlag).patch()
 	} else if uninstall {
 		errSilent = PromptDiscord("unpatch", *locationFlag, *branchFlag).unpatch()
-	} else if update {
-		Log.Info("Downloading latest Equicord files...")
+    } else if update {
+        Log.Info("Downloading latest Privcord files...")
 		err := installLatestBuilds()
 		Log.Info("Done!")
 		if err == nil {
@@ -277,5 +277,5 @@ func HandleScuffedInstall() {
 	fmt.Println("Hold On!")
 	fmt.Println("You have a broken Discord Install.")
 	fmt.Println("Please reinstall Discord before proceeding!")
-	fmt.Println("Otherwise, Equicord will likely not work.")
+    fmt.Println("Otherwise, Privcord will likely not work.")
 }

--- a/constants.go
+++ b/constants.go
@@ -11,12 +11,12 @@ import (
 	"vencord/buildinfo"
 )
 
-const ReleaseUrl = "https://api.github.com/repos/Equicord/Equicord/releases/latest"
-const ReleaseUrlFallback = "https://equicord.org/releases/equicord"
-const InstallerReleaseUrl = "https://api.github.com/repos/Equicord/Equilotl/releases/latest"
-const InstallerReleaseUrlFallback = "https://equicord.org/releases/equilotl"
+const ReleaseUrl = "https://api.github.com/repos/kanvekin/Privcord/releases/latest"
+const ReleaseUrlFallback = "https://api.github.com/repos/kanvekin/Privcord/releases/latest"
+const InstallerReleaseUrl = "https://api.github.com/repos/kanvekin/Privcord/releases/latest"
+const InstallerReleaseUrlFallback = "https://api.github.com/repos/kanvekin/Privcord/releases/latest"
 
-var UserAgent = "Equilotl/" + buildinfo.InstallerGitHash + " (https://github.com/Equicord/Equilotl)"
+var UserAgent = "Equilotl/" + buildinfo.InstallerGitHash + " (https://github.com/kanvekin/Privcord)"
 
 var (
 	DiscordGreen  = color.RGBA{R: 0x2D, G: 0x7C, B: 0x46, A: 0xFF}

--- a/gui.go
+++ b/gui.go
@@ -124,10 +124,10 @@ func InstallLatestBuilds() (err error) {
 		return
 	}
 
-	err = installLatestBuilds()
-	if err != nil {
-		ShowModal("Uh Oh!", "Failed to install the latest Equicord builds from GitHub:\n"+err.Error())
-	}
+    err = installLatestBuilds()
+    if err != nil {
+        ShowModal("Uh Oh!", "Failed to install the latest Privcord builds from GitHub:\n"+err.Error())
+    }
 	return
 }
 
@@ -432,14 +432,14 @@ func renderInstaller() g.Widget {
 		g.Separator(),
 		g.Dummy(0, 5),
 
-		g.Style().SetFontSize(20).To(
-			renderErrorCard(
-				DiscordYellow,
-				"**Github** and **equicord.org** are the only official places to get Equicord. Any other site claiming to be us is malicious.\n"+
-					"If you downloaded from any other source, you should delete / uninstall everything immediately, run a malware scan and change your Discord password.",
-				90,
-			),
-		),
+        g.Style().SetFontSize(20).To(
+            renderErrorCard(
+                DiscordYellow,
+                "**GitHub** is the only official place to get Privcord: https://github.com/kanvekin/Privcord. Any other site claiming to be us is malicious.\n"+
+                    "If you downloaded from any other source, you should delete / uninstall everything immediately, run a malware scan and change your Discord password.",
+                90,
+            ),
+        ),
 
 		g.Dummy(0, 5),
 
@@ -547,7 +547,7 @@ func renderInstaller() g.Widget {
 								}
 							}).
 							Size((w-40)/4, 50),
-						Tooltip("Reinstall & Update Equicord"),
+                        Tooltip("Reinstall & Update Privcord"),
 					),
 				g.Style().
 					SetColor(g.StyleColorButton, DiscordRed).
@@ -568,17 +568,17 @@ func renderInstaller() g.Widget {
 			),
 		),
 
-		InfoModal("#patched", "Successfully Patched", "If Discord is still open, fully close it first.\n"+
-			"Then, start it and verify Equicord installed successfully by looking for its category in Discord Settings"),
+        InfoModal("#patched", "Successfully Patched", "If Discord is still open, fully close it first.\n"+
+            "Then, start it and verify Privcord installed successfully by looking for its category in Discord Settings"),
 		InfoModal("#unpatched", "Successfully Unpatched", "If Discord is still open, fully close it first. Then start it again, it should be back to stock!"),
 		InfoModal("#scuffed-install", "Hold On!", "You have a broken Discord Install.\n"+
 			"Sometimes Discord decides to install to the wrong location for some reason!\n"+
-			"You need to fix this before patching, otherwise Equicord will likely not work.\n\n"+
+            "You need to fix this before patching, otherwise Privcord will likely not work.\n\n"+
 			"Use the below button to jump there and delete any folder called Discord or Squirrel.\n"+
 			"If the folder is now empty, feel free to go back a step and delete that folder too.\n"+
 			"Then see if Discord still starts. If not, reinstall it"),
-		RawInfoModal("#openasar-confirm", "OpenAsar", "OpenAsar is an open-source alternative of Discord desktop's app.asar.\n"+
-			"Equicord is in no way affiliated with OpenAsar.\n"+
+        RawInfoModal("#openasar-confirm", "OpenAsar", "OpenAsar is an open-source alternative of Discord desktop's app.asar.\n"+
+            "Privcord is in no way affiliated with OpenAsar.\n"+
 			"You're installing OpenAsar at your own risk. If you run into issues with OpenAsar,\n"+
 			"no support will be provided, join the OpenAsar Server instead!\n\n"+
 			"To install OpenAsar, press Accept and click 'Install OpenAsar' again.", true),
@@ -638,30 +638,30 @@ func loop() {
 			g.Dummy(0, 20),
 			g.Style().SetFontSize(20).To(
 				g.Row(
-					g.Label(Ternary(IsDevInstall, "Dev Install: ", "Equicord will be downloaded to: ")+EquicordDirectory),
+                    g.Label(Ternary(IsDevInstall, "Dev Install: ", "Privcord will be downloaded to: ")+PrivcordDirectory),
 					g.Style().
 						SetColor(g.StyleColorButton, DiscordBlue).
 						SetStyle(g.StyleVarFramePadding, 4, 4).
 						To(
-							g.Button("Open Directory").OnClick(func() {
-								g.OpenURL("file://" + path.Dir(EquicordDirectory))
-							}),
+                            g.Button("Open Directory").OnClick(func() {
+                                g.OpenURL("file://" + path.Dir(PrivcordDirectory))
+                            }),
 						),
 				),
-				&CondWidget{!IsDevInstall, func() g.Widget {
-					return g.Label("To customise this location, set the environment variable 'EQUICORD_USER_DATA_DIR' and restart me").Wrapped(true)
-				}, nil},
+                &CondWidget{!IsDevInstall, func() g.Widget {
+                    return g.Label("To customise this location, set the environment variable 'PRIVCORD_USER_DATA_DIR' and restart me").Wrapped(true)
+                }, nil},
 				g.Dummy(0, 10),
-				g.Label("Equilotl Version: "+buildinfo.InstallerTag+" ("+buildinfo.InstallerGitHash+")"+Ternary(IsSelfOutdated, " - OUTDATED", "")),
-				g.Label("Local Equicord Version: "+InstalledHash),
+                g.Label("Equilotl Version: "+buildinfo.InstallerTag+" ("+buildinfo.InstallerGitHash+")"+Ternary(IsSelfOutdated, " - OUTDATED", "")),
+                g.Label("Local Privcord Version: "+InstalledHash),
 				&CondWidget{
 					GithubError == nil,
-					func() g.Widget {
-						if IsDevInstall {
-							return g.Label("Not updating Equicord due to being in DevMode")
-						}
-						return g.Label("Latest Equicord Version: " + LatestHash)
-					}, func() g.Widget {
+                    func() g.Widget {
+                        if IsDevInstall {
+                            return g.Label("Not updating Privcord due to being in DevMode")
+                        }
+                        return g.Label("Latest Privcord Version: " + LatestHash)
+                    }, func() g.Widget {
 						return renderErrorCard(DiscordRed, "Failed to fetch Info from GitHub: "+GithubError.Error(), 40)
 					},
 				},

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$link = "https://github.com/Equicord/Equilotl/releases/latest/download/EquilotlCli.exe"
+$link = "https://github.com/kanvekin/Privcord/releases/latest/download/EquilotlCli.exe"
 
 $outfile = "$env:TEMP\EquilotlCli.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ echo "Downloading Installer..."
 
 set -- "XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
 
-curl -sS https://github.com/Equicord/Equilotl/releases/latest/download/EquilotlCli-Linux \
+curl -sS https://github.com/kanvekin/Privcord/releases/latest/download/EquilotlCli-Linux \
   --output "$outfile" \
   --location \
   --fail

--- a/patcher.go
+++ b/patcher.go
@@ -18,36 +18,66 @@ import (
 
 var BaseDir string
 var BaseDirErr error
-var EquicordDirectory string
+// PrivcordDirectory is the path to the installed Privcord .asar (or dev dir)
+// Keep old Equicord envs as fallback for compatibility
+var PrivcordDirectory string
 
 func init() {
-	if dir := os.Getenv("EQUICORD_USER_DATA_DIR"); dir != "" {
-		Log.Debug("Using EQUICORD_USER_DATA_DIR")
-		BaseDir = dir
-	} else if dir = os.Getenv("DISCORD_USER_DATA_DIR"); dir != "" {
-		Log.Debug("Using DISCORD_USER_DATA_DIR/../EquicordData")
-		BaseDir = path.Join(dir, "..", "EquicordData")
-	} else {
-		Log.Debug("Using UserConfig")
-		BaseDir = appdir.New("Equicord").UserConfig()
-	}
-	dir := os.Getenv("EQUICORD_DIRECTORY")
-	if dir == "" {
-		if !ExistsFile(BaseDir) {
-			BaseDirErr = os.Mkdir(BaseDir, 0755)
-			if BaseDirErr != nil {
-				Log.Error("Failed to create", BaseDir, BaseDirErr)
-			} else {
-				BaseDirErr = FixOwnership(BaseDir)
-			}
-		}
-	}
-	if dir != "" {
-		Log.Debug("Using EQUICORD_DIRECTORY")
-		EquicordDirectory = dir
-	} else {
-		EquicordDirectory = path.Join(BaseDir, "equicord.asar")
-	}
+    // Determine BaseDir
+    if dir := firstNonEmpty(
+        os.Getenv("PRIVCORD_USER_DATA_DIR"),
+        os.Getenv("EQUICORD_USER_DATA_DIR"), // legacy env var support
+    ); dir != "" {
+        Log.Debug("Using ", ternary(dir == os.Getenv("PRIVCORD_USER_DATA_DIR"), "PRIVCORD_USER_DATA_DIR", "EQUICORD_USER_DATA_DIR"))
+        BaseDir = dir
+    } else if dir = os.Getenv("DISCORD_USER_DATA_DIR"); dir != "" {
+        Log.Debug("Using DISCORD_USER_DATA_DIR/../PrivcordData")
+        BaseDir = path.Join(dir, "..", "PrivcordData")
+    } else {
+        Log.Debug("Using UserConfig")
+        // App name for per-user config folder
+        BaseDir = appdir.New("Privcord").UserConfig()
+    }
+
+    // Ensure BaseDir exists when not overridden directly via *_DIRECTORY
+    dir := firstNonEmpty(os.Getenv("PRIVCORD_DIRECTORY"), os.Getenv("EQUICORD_DIRECTORY"))
+    if dir == "" {
+        if !ExistsFile(BaseDir) {
+            BaseDirErr = os.Mkdir(BaseDir, 0755)
+            if BaseDirErr != nil {
+                Log.Error("Failed to create", BaseDir, BaseDirErr)
+            } else {
+                BaseDirErr = FixOwnership(BaseDir)
+            }
+        }
+    }
+
+    // Choose PrivcordDirectory
+    if dir != "" {
+        Log.Debug("Using ", ternary(os.Getenv("PRIVCORD_DIRECTORY") != "", "PRIVCORD_DIRECTORY", "EQUICORD_DIRECTORY"))
+        PrivcordDirectory = dir
+    } else {
+        // default filename renamed to privcord.asar
+        PrivcordDirectory = path.Join(BaseDir, "privcord.asar")
+    }
+}
+
+// helper: return first non-empty string
+func firstNonEmpty(values ...string) string {
+    for _, v := range values {
+        if v != "" {
+            return v
+        }
+    }
+    return ""
+}
+
+// helper ternary
+func ternary(cond bool, a, b string) string {
+    if cond {
+        return a
+    }
+    return b
 }
 
 type DiscordInstall struct {
@@ -99,7 +129,7 @@ func patchAppAsar(dir string, isSystemElectron bool) (err error) {
 	}
 
 	Log.Debug("Writing custom app.asar to", appAsar)
-	if err := WriteAppAsar(appAsar, EquicordDirectory); err != nil {
+    if err := WriteAppAsar(appAsar, PrivcordDirectory); err != nil {
 		return err
 	}
 
@@ -149,14 +179,14 @@ func (di *DiscordInstall) patch() error {
 			}
 		}
 
-		Log.Debug("This is a flatpak. Trying to grant the Flatpak access to", EquicordDirectory+"...")
+        Log.Debug("This is a flatpak. Trying to grant the Flatpak access to", PrivcordDirectory+"...")
 
 		isSystemFlatpak := strings.HasPrefix(di.path, "/var")
 		var args []string
 		if !isSystemFlatpak {
 			args = append(args, "--user")
 		}
-		args = append(args, "override", name, "--filesystem="+EquicordDirectory)
+        args = append(args, "override", name, "--filesystem="+PrivcordDirectory)
 		fullCmd := "flatpak " + strings.Join(args, " ")
 
 		Log.Debug("Running", fullCmd)
@@ -177,7 +207,7 @@ func (di *DiscordInstall) patch() error {
 			err = cmd.Run()
 		}
 		if err != nil {
-			return errors.New("Failed to grant Discord Flatpak access to " + EquicordDirectory + ": " + err.Error())
+            return errors.New("Failed to grant Discord Flatpak access to " + PrivcordDirectory + ": " + err.Error())
 		}
 	}
 	return nil

--- a/self_updater.go
+++ b/self_updater.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func GetInstallerDownloadLink() string {
-	const BaseUrl = "https://github.com/Equicord/Equilotl/releases/latest/download/"
+    const BaseUrl = "https://github.com/kanvekin/Privcord/releases/latest/download/"
 	switch runtime.GOOS {
 	case "windows":
 		filename := Ternary(buildinfo.UiType == buildinfo.UiTypeCli, "EquilotlCli.exe", "Equilotl.exe")

--- a/winres/winres.json
+++ b/winres/winres.json
@@ -9,7 +9,7 @@
   "RT_MANIFEST": {
     "#1": {
       "0409": {
-        "description": "An Installer for the Equicord Discord Mod",
+        "description": "An Installer for the Privcord Discord Mod",
         "minimum-os": "win10",
         "execution-level": "as invoker",
         "dpi-awareness": "system"
@@ -22,7 +22,7 @@
         "info": {
           "0409": {
             "Comments": "Comments",
-            "CompanyName": "Equicord",
+            "CompanyName": "Privcord",
             "FileDescription": "Equilotl",
             "LegalCopyright": "© 2025 Vendicated and Vencord contributors - GPL3.0",
             "ProductName": "Equilotl",


### PR DESCRIPTION
Rebrand the project from Equicord to Privcord and update all associated URLs to reflect the new `kanvekin/Privcord` repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-64d54cd6-3115-48d4-9965-2b70865ac33b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64d54cd6-3115-48d4-9965-2b70865ac33b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

