### PR TITLE
Update equicord release configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -tags "static gui" -ldflags "-s -w -X 'vencord/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencord/buildinfo.InstallerTag=${{ github.ref_name }}'" -o Equilotl-x11
 
       - name: Build CLI
-        run: CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -tags "cli" -ldflags "-s -w -X 'vencord/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencord/buildinfo.InstallerTag=${{ github.ref_name }}'" -o EquilotlCli-linux
+        run: CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -tags "cli" -ldflags "-s -w -X 'vencord/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencord/buildinfo.InstallerTag=${{ github.ref_name }}'" -o EquilotlCli-Linux
 
       - name: Update executable
         run: |
@@ -58,7 +58,7 @@ jobs:
           name: Equilotl-linux
           path: |
             Equilotl-x11
-            EquilotlCli-linux
+            EquilotlCli-Linux
 
 
   build-mac:
@@ -219,6 +219,6 @@ jobs:
             This is release ${{ github.ref_name }} of Equilotl.
           files: |
             linux/Equilotl-x11
-            linux/EquilotlCli-linux
+            linux/EquilotlCli-Linux
             macos/Equilotl.MacOS.zip
             windows/Equilotl*.exe


### PR DESCRIPTION
Update Linux CLI artifact name in `release.yml` to `EquilotlCli-Linux` for consistency.

This change ensures the artifact name matches what is used in `README.md` and `install.sh`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c146667-0994-4941-8465-3246602fa3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c146667-0994-4941-8465-3246602fa3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

